### PR TITLE
renovate automerges via branch, not PR

### DIFF
--- a/.github/workflows/codespell-local.yml
+++ b/.github/workflows/codespell-local.yml
@@ -3,7 +3,6 @@ name: Codespell - Spellcheck
 
 on:  # yamllint disable-line rule:truthy
   push:
-    branches: [main]
   pull_request:
     branches: [main]
 

--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,8 @@
         "patch",
         "minor"
       ],
-      "automerge": true
+      "automerge": true,
+      "automergeType": "branch"
     }
   ]
 }


### PR DESCRIPTION
From https://docs.renovatebot.com/configuration-options/#automergetype:

> If you prefer that Renovate more silently automerge without Pull Requests at all, you can configure "automergeType": "branch". In this case Renovate will:
> 
> -    Create the branch, wait for test results
> -    Rebase it any time it gets out of date with the base branch
> -    Automerge the branch commit if it's: (a) up-to-date with the base branch, and (b) passing all tests
> -    As a backup, raise a PR only if either: (a) tests fail, or (b) tests remain pending for too long (default: 24 hours)


This way we only get PRs and notifications when somethings fails. Makes my inbox less noisy.
We probably have to change our actions so they only run on branches (as described [here](https://futurestud.io/tutorials/github-actions-run-on-push-or-pull-request-but-not-both)).

What do you think, @schurzi and @michaelamattes ?